### PR TITLE
fixed the naming issue for a category

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,16 +247,16 @@
 
                 <div class="card-icon">
                   <img src="./assets/images/category-5.svg" width="72" height="72" loading="lazy"
-                    alt="Data Science icon">
+                    alt="Data Analytics icon">
                 </div>
 
                 <div>
-                  <h3 class="title-lg">Data Science</h3>
+                  <h3 class="title-lg">Data Analytics</h3>
 
                   <p class="title-sm">68 Courses</p>
                 </div>
 
-                <a href="#" class="layer-link" aria-label="Data Science Category"></a>
+                <a href="#" class="layer-link" aria-label="Data Analytics Category"></a>
 
               </div>
             </li>


### PR DESCRIPTION
Issue no: Fixing a naming bug #67
There were two categories having same name i.e. Data Science. I changed the second course name to Data Analytics.
Before : 
![Screenshot 2024-10-02 112656](https://github.com/user-attachments/assets/657bff7b-5876-49f9-9e04-ec5e7f419abd)
After : 
![Screenshot 2024-10-02 112715](https://github.com/user-attachments/assets/b87262cd-4fcc-411b-b082-05c69aa73371)