### PR TITLE
ui:fix UI visibility in dark mode fix #143

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1077,6 +1077,11 @@ body.dark-mode .btn {
   color: var(--oxford-blue);
 }
 
+body.dark-mode .btn-tertiary {
+  background-color: var(--oxford-blue);
+  color: var(--white);
+}
+
 body.dark-mode #theme-toggle {
   background-color: var(--oxford-blue);
 


### PR DESCRIPTION
Corrected the visibility of the 'Register Today' button to ensure it is clearly visible in dark mode.
## Before
![image](https://github.com/user-attachments/assets/cec2a80a-c000-49e6-82c2-7ff9273c15e8)

## After
![image](https://github.com/user-attachments/assets/0f64bf90-4386-4ec4-82ea-e476f73df82f)

