### PR TITLE
Fix #121 : Fix Dark Mode Text Contrast Issue on "About SkillWise" Section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -226,6 +226,10 @@ body.nav-active { overflow: hidden; }
 
 .section-title { margin-block-end: 24px; }
 
+body.dark-mode .section-title {
+  color: var(--white);
+}
+
 .headline-md .has-after { padding-block-end: 8px; }
 
 .headline-md .has-after::after {
@@ -484,9 +488,13 @@ body.nav-active { overflow: hidden; }
   margin-block-end: 8px;
 }
 
-.progress-label-wrapper .title-sm {
-  color: var(--oxford-blue);
+body.dark-mode .progress-label-wrapper .title-sm {
+  color: var(--white);
   font-weight: var(-fw-600);
+}
+
+body.dark-mode headline-md text-center section-title aos-init aos-animate{
+  color: var(--white);
 }
 
 .progress {
@@ -1095,7 +1103,6 @@ body.dark-mode h1{
   color: var(--oxford-blue);
 }
 
-}
 form {
   max-width: 400px;
   margin: auto;


### PR DESCRIPTION
**Description:** 
This PR addresses the issue of low text visibility in the dark mode for the "About SkillWise" section. The current design uses a dark background, and some text elements blend into the background, reducing readability. This fix ensures better color contrast between the text and background to enhance readability.

**Changes Made:**

- Updated the color palette for dark mode to improve contrast.
- Adjusted the text color of headings and body text to lighter shades for better readability.
- Ensured the progress bars also have enough contrast for visibility in dark mode.

**Before:**
![image](https://github.com/user-attachments/assets/82171183-9be5-4b18-8aaf-ef80e53ab173)
The "Education" header and body text had insufficient contrast against the dark background, making it hard to read.

**After:**
![image](https://github.com/user-attachments/assets/9308cdf8-76e9-45af-ba0c-1b0e761f8001)
The "Education" header and body text had insufficient contrast against the dark background, making it hard to read.

Tested the updated color scheme in both light and dark mode.
Verified that the text is now clearly visible on different screen types and resolutions.

Fixes Issue: Resolves #121 