### PR TITLE
Fix FAQ Page: Plus to Minus Icon Toggle and Add Padding for Better Layout

### DIFF
--- a/Faq.html
+++ b/Faq.html
@@ -121,7 +121,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">1. What type of courses does SkillWise offer?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>SkillWise offers a wide range of courses across various categories, including Data Science, UI/UX
@@ -132,7 +132,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">2. What payment methods are accepted?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>We accept a variety of payment methods including credit/debit cards, PayPal, and other online
@@ -143,7 +143,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">3. Will I receive a certificate after completing a course?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>Yes! All courses provide a certificate of completion that can be downloaded and added to your
@@ -154,7 +154,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">4. What should I do if I encounter issues with the course videos?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>If you're experiencing problems with video playback or course content, try refreshing your
@@ -166,7 +166,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">5. How long do I have access to a course after purchasing it?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>Once you purchase a course, you get lifetime access, allowing you to learn at your own pace.</p>
@@ -176,7 +176,7 @@
             <div class="item" data-aos="fade-down">
                 <div class="FAQ-title">
                     <p class="faqQuestion">6. Do I need any prerequisites to enroll in a course?</p>
-                    <span class="expandToggle">+</span>
+                    <span class="expandToggle"><p class="expand">+</p><p class="revert">-</p></span>
                 </div>
                 <div class="FAQ-content">
                     <p>Most beginner courses do not require any prerequisites, but intermediate and advanced courses

--- a/assets/css/Faq.css
+++ b/assets/css/Faq.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
+  padding-bottom: 8%;
 }
 
 .accordian {
@@ -84,6 +85,11 @@
   font-weight: 600;
 }
 
+.revert {
+  display: none;
+  padding-bottom: 2px;
+}
+
 .FAQ-ShowMore {
   text-align: center;
   margin-top: 10px;
@@ -131,6 +137,10 @@
     padding: 10px;
   }
 
+  #FAQ {
+    padding-bottom: 15%;
+  }
+
   .item {
     padding: 10px 14px;
   }
@@ -149,6 +159,10 @@
 @media (max-width: 480px) {
   .accordian {
     padding: 5px;
+  }
+
+  #FAQ {
+    padding-bottom: 15%;
   }
 
   .item {

--- a/assets/js/scriptfaq.js
+++ b/assets/js/scriptfaq.js
@@ -3,21 +3,40 @@ document.addEventListener("DOMContentLoaded", () => {
     const showMoreBtn = document.getElementById("showMoreBtn");
     let showMore = false;
   
-    items.forEach((item, index) => {
-      item.querySelector(".FAQ-title").addEventListener("click", () => {
-        if (item.classList.contains("selected")) {
-          item.classList.remove("selected");
-          item.querySelector(".FAQ-content").classList.remove("show");
-        } else {
-          document.querySelectorAll(".item").forEach((el) => {
-            el.classList.remove("selected");
-            el.querySelector(".FAQ-content").classList.remove("show");
-          });
-          item.classList.add("selected");
-          item.querySelector(".FAQ-content").classList.add("show");
+    items.forEach((item) => {
+      const title = item.querySelector(".FAQ-title");
+      const content = item.querySelector(".FAQ-content");
+      const expandIcon = item.querySelector(".expand");
+      const revertIcon = item.querySelector(".revert");
+    
+      title.addEventListener("click", () => {
+        const isOpen = item.classList.contains("selected");
+    
+        // Close all open items
+        closeAllItems();
+    
+        if (!isOpen) {
+          // Open the clicked item
+          openItem(item, expandIcon, revertIcon, content);
         }
       });
     });
+
+    function closeAllItems() {
+      items.forEach((el) => {
+        el.classList.remove("selected");
+        el.querySelector(".FAQ-content").classList.remove("show");
+        el.querySelector(".expand").style.display = "flex"; // Show plus icon
+        el.querySelector(".revert").style.display = "none"; // Hide minus icon
+      });
+    }
+    
+    function openItem(item, expandIcon, revertIcon, content) {
+      item.classList.add("selected");
+      content.classList.add("show");
+      expandIcon.style.display = "none"; // Hide plus icon
+      revertIcon.style.display = "flex"; // Show minus icon
+    }
   
     showMoreBtn.addEventListener("click", () => {
       showMore = !showMore;


### PR DESCRIPTION
#Issue 185
This pull request addresses two issues on the FAQ page:

**- Plus to Minus Toggle on Question Expansion:**
When a question is clicked to view the answer, the plus sign (+) now changes to a minus sign (−) to indicate that the answer is expanded and can be closed.
I have ensured that when another question is clicked, the previous question collapses, and its icon reverts to the plus sign.

**- Added Padding for Better Layout:**
Added padding below the FAQ page end to improve the readability and overall layout of the page.

**Changes Made:**
- Refactored the toggle logic in the JavaScript to manage the icon switching between plus and minus when expanding/collapsing FAQ items.
- Applied padding in the CSS to ensure there is enough spacing at the end of the FAQ page.
- Ensured only one question is expanded at a time, improving the user experience.

**Screenshots**
-Before:
![Screenshot 2024-10-04 231922](https://github.com/user-attachments/assets/32969bdc-7644-4f2e-99af-c1fc0970f6a1)

-After:
![Screenshot 2024-10-04 232011](https://github.com/user-attachments/assets/0ac6e14e-c4b5-481c-9caf-a3d0c0206b22)

**Testing:**
- I manually tested the FAQ section by expanding and collapsing multiple questions and ensured the icon switches as expected.
- Verified that the padding improves the layout by checking on different screen sizes to ensure responsiveness.