### PR TITLE
Fix 230: Added Issues templates

### DIFF
--- a/.github/BUG_report_issue_template.md
+++ b/.github/BUG_report_issue_template.md
@@ -1,0 +1,35 @@
+### Title of the Issue
+- [ ] **Have you named the issue title clearly and descriptively?**
+- [ ] **Have you searched for existing issues in the project to avoid duplicates?**  
+<!-- Example: "Bug: [Component] Button not responding on click" -->
+<!-- Use format: "Bug: [affected section] concise description" -->
+
+### Description
+<!-- A clear and detailed description of the bug, including what happens, how it happens, and any potential consequences. -->
+
+### Steps to Reproduce
+<!-- List out the steps to reproduce the bug, including the code, environment, or any specific conditions. -->
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+### Changes Expected
+<!-- Describe what changes you wish to make in the code. -->
+
+### Screenshots / Logs
+<!-- If applicable, attach screenshots, logs, or any other files to help understand the issue. -->
+
+### Related Issues or Pull Requests
+<!-- If this issue is related to other issues or pull requests, mention them here by linking the relevant numbers. -->
+
+### Environment
+<!-- Provide details about the environment where the issue was observed (e.g., OS, browser, or framework version). -->
+
+### Checklist
+- [ ] I have followed the issue title guidelines.
+- [ ] I have included a clear and detailed description.
+- [ ] I have provided necessary logs, screenshots, or other files.
+- [ ] I am a GSSOC contributor.
+- [ ] I have mentioned related issues or pull requests if any.
+- [ ] I have provided details about the environment where the issue was observed.

--- a/.github/Feature_request_issue_template.md
+++ b/.github/Feature_request_issue_template.md
@@ -1,0 +1,29 @@
+### Title of the Issue
+- [ ] **Have you named the issue title clearly and descriptively?**
+- [ ] **Have you searched for existing issues in the project to avoid duplicates?**
+<!-- Example: "feat: [Component] Add social media sharing functionality" -->
+<!-- Use format: "feat: [affected section] concise description" -->
+
+### Description
+<!-- A clear and detailed description of the feature, including the problem you're addressing, the solution you're proposing, and any relevant details. -->
+
+### Approach to Creating This Feature
+<!-- Describe your approach to creating this feature. How does it integrate with existing components or functionality? Provide examples or ideas. -->
+
+### Benefits
+<!-- Explain the benefits of this feature. How will it improve the project or user experience? -->
+
+### Social Links / References
+<!-- If relevant, provide links to other resources (social media links, GitHub repos, examples) that may help understand or enhance the feature. -->
+
+### Additional Context
+<!-- Add any other relevant information, such as user stories, use cases, or mockups, to provide more detail about the feature request. -->
+
+### Checklist
+- [ ] I have followed the issue title guidelines.
+- [ ] I have clearly described the feature and its approach.
+- [ ] I have explained the benefits of this feature.
+- [ ] I have added references or social links, where applicable.
+- [ ] I have provided additional context, if necessary.
+- [ ] I have read the GSSOC guidelines and understand the contribution process.
+- [ ] I have checked for existing issues and pull requests to avoid duplicates.

--- a/.github/Pull_Request_template.md
+++ b/.github/Pull_Request_template.md
@@ -1,0 +1,47 @@
+### Title of the Pull Request
+- [ ] Have you renamed the PR Title in a meaningful way?
+<!-- 
+Examples of good PR titles:
+
+build:      (for build related changes)
+chore:      (for updating task runner configs etc; no production code change)
+docs:       (for documentation changes)
+feat:       (for new feature)
+fix:        (for bug fixes)
+perf:       (for performance improvements)
+refactor:   (for refactoring code; no production code change)
+revert:     (when reverting changes)
+style:      (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
+test:       (when adding missing tests)
+-->
+### Related Issue
+<!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
+Closes: #<issue number>
+
+### Description
+<!-- Describe the changes you made in this pull request in DETAILS-->
+
+### Type of change
+
+What sort of changes have you made:
+<!--
+Example how to mark a checkbox:-
+- [x] My code follows the code style of this project.
+-->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Code style update (formatting, local variables)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### Checklist
+<!--
+Example how to mark a checkbox:-
+- [x] My code follows the code style of this project.
+-->
+- [ ] My code follows the code style of this project.
+- [ ] I have followed the contribution guidelines
+- [ ] I have performed a self-review of my own code.
+- [ ] I have ensured my changes don't generate any new warnings or errors.
+- [ ] I have updated the documentation (if necessary).
+- [ ] I have resolved all merge conflicts.


### PR DESCRIPTION
### Fix 230: Add Issues templates

### Related Issue
Closes: #230 

### **Description**
This PR fixes the issue #230, It includes issue templates that lets new contributors raise issue for particular category such as **Bug-report**, **Feature-request** and **Pull Request** within the repository. Detailed & informative with lots of particulars to be filled that allows the maintainer to see what the contributors wants to do, their approach & what changes are they going to merge in the ***main*** branch.

### New Templates for Issue and Pull Request Submission:

* [`.github/BUG_report_issue_template.md`](diffhunk://#diff-b764e6fb2d10671d6cb2597a35bf6445e1b89540265c0b010de8d5b72315cdd3R1-R35): Added a detailed template for bug reports, including sections for title, description, steps to reproduce, expected changes, screenshots/logs, related issues, environment, and a checklist for contributors.
* [`.github/Feature_request_issue_template.md`](diffhunk://#diff-712a6431ac240a4550247261701c42a4c6d7b9a497cf40fd0ff18ef9ae2e1e92R1-R29): Introduced a comprehensive template for feature requests, covering title, description, approach, benefits, social links/references, additional context, and a checklist for contributors.
* [`.github/Pull_Request_template.md`](diffhunk://#diff-c710f5ed7890dd18e8c61a036ace3fd59ebf932352fde36aac92b35d70e7cb09R1-R47): Created a structured template for pull requests, including sections for title, related issue, description, type of change, and a checklist to ensure code quality and adherence to guidelines.

---

@PriyaGhosal Please review my PR and add labels to it.