### PR TITLE
Updated button style

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -441,6 +441,7 @@ body.nav-active { overflow: hidden; }
 .hero .btn-group {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 }
 


### PR DESCRIPTION
The get started now buttons are positions centrally to improve the visual appeal of the site.
 
Before:
![btn-before](https://github.com/user-attachments/assets/e54e3e23-9dde-404d-8487-44dfd4d79b10)

After:
![button-after](https://github.com/user-attachments/assets/a3d9cb39-bf19-4f7d-83ce-638bf206d714)

This is my contribution under Hacktoberfest 2024.

Thank you!