### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,14 +105,14 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
+    "version": "0.7.0",
+    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+    "integrity": "<integrity-value>",
+    "license": "MIT",
+    "engines": {
+    "node": ">= 0.6"
+  }
+}
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",


### PR DESCRIPTION
Hello @PriyaGhosal 

Affected versions of node_modules/cookie are vulnerable to Improper Neutralization of Special Elements in Output  Used by a Downstream Component ('Injection').

Fixed for cookie at version: 0.7.0 so kindly update the version of node_modules/cookie to 0.7.0. 

Path : https://github.com/PriyaGhosal/SkillWise/blob/main/package-lock.json

reference: https://nvd.nist.gov/vuln/detail/CVE-2024-47764

