### PR TITLE
fix: Validate Sign-up page Name Field to Accept Only Letters

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -20,7 +20,8 @@
             <form action="#" method="POST">
                 <div class="input-group">
                     <label for="username">Full Name</label>
-                    <input type="text" id="fullname" name="fullname" placeholder="Create your username" required>
+                    <input type="text" id="fullname" name="fullname" placeholder="Create your username" required required pattern="[a-zA-Z ]+" oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')" 
+                    oninput="this.setCustomValidity('')">
                 </div>
                 <div class="input-group">
                     <label for="username">Username</label>


### PR DESCRIPTION
### Title of the Pull Request

Validate the Sign-up page Name Field to Accept Only Letters.

Closes: #468  

### Description
This PR addresses Issue #468  by implementing validation on the Sign-up form Name field to only accept alphabetical letters.

### Type of change

Added validation using the setCustomValidity method.

![image](https://github.com/user-attachments/assets/21adf19e-b536-4219-89ce-301f3c2f9200)



**Checkbox:-**

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.