### PR TITLE
fix: Validate Contact Us Name Field to Accept Only Letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1374,7 +1374,8 @@
       " onmouseover="this.style.boxShadow='0 10px 20px rgba(0, 0, 0, 0.2)'"
           onmouseout="this.style.boxShadow='0 6px 12px rgba(0, 0, 0, 0.15)'">
 
-          <input type="text" name="name" placeholder="Your Name" required style="
+          <input type="text" name="name" placeholder="Your Name" required  required pattern="[a-zA-Z ]+" oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')" 
+          oninput="this.setCustomValidity('')" style="
           width: 100%;
           padding: 12px;
           margin: 8px 0;


### PR DESCRIPTION
### Title of the Pull Request

Validate Contact Us section's Name Field to Accept Only Letters.

Closes: #451 

### Description
This PR addresses Issue #451 by implementing validation on the Contact Us form's Name field to only accept alphabetical letters.

### Type of change

Added validation using the setCustomValidity method.

![image](https://github.com/user-attachments/assets/71103cb4-bb24-4985-80aa-bbd322c03200)


**Checkbox:-**

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.