### PR TITLE
Event section paragraph color was not visible to user

### DIFF
--- a/assets/css/darkmode.css
+++ b/assets/css/darkmode.css
@@ -130,6 +130,7 @@ body.nav-active { overflow: hidden; }
 .title-lg {
   color: var(--white);
   font-weight: var(--fw-700);
+  padding: 10px;
 }
 
 .headline-lg {
@@ -225,6 +226,7 @@ body.nav-active { overflow: hidden; }
 .grid-list {
   display: grid;
   gap: 28px;
+  margin-bottom: 30px;
 }
 
 .card {

--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@
 
 .event-description {
   font-size: 1.4rem; /* Larger description font size */
-  color: var(--oxford-blue); /* Roman silver for descriptions */
+  color: rgba(240, 74, 74, 0.862) /* Roman silver for descriptions */
 }
 
 /* Event button */


### PR DESCRIPTION
@PriyaGhosal

what does this PR do

Fixes #485 

As per the issue, the paragraph of the Event section was not visible due to its color this PR changed the color of paragraph now its visible to the user.


FROM
![image](https://github.com/user-attachments/assets/dbaaf181-735d-4bc5-87ec-9dfca3ab41ce)


TO
![image](https://github.com/user-attachments/assets/a74be070-94d3-4aad-969f-05324377b07d)
