### PR TITLE
Fix Footer Copyright Text Alignment 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,6 +101,7 @@ ion-icon {
 }
 
 a {
+  display: block;
   text-decoration: none;
   color: inherit;
 }


### PR DESCRIPTION
This pull request addresses the alignment issue of the copyright text in the footer when the application is in light mode. The CSS was updated to set the copyright text's display property to block, ensuring that it is centered properly within the footer.

Before:
![image](https://github.com/user-attachments/assets/de2c6035-3245-4567-9917-1da67eaab034)

After:
![image](https://github.com/user-attachments/assets/df9fc016-94c7-435f-b760-04026281dc7a)

Closes: #530 