### PR TITLE
ADD VIDEO OF WEBSITE IN WEBSITE PREVIEW IN README #724

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # `SkillWise`
 <br>
 https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
-
 <br>
 <img src='./readme-images/desktop.png'>
 <br>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # `SkillWise`
 <br>
-
+# `SkillWise`
+<br>
 
 https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # `SkillWise`
 <br>
-https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+
+
+https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57
+
+
 <br>
 <img src='./readme-images/desktop.png'>
 <br>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 _<i>SkillWise is an innovative online platform designed to help learners of all ages acquire new skills and knowledge. With a wide range of engaging courses and expert instructors, SkillWise provides the tools you need to succeed in today’s competitive world.</i>_
 
 <br>
+https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+<br>
 
 <table align="center">
     <thead align="center">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `SkillWise`
 <br>
-# `SkillWise`
+Website Preview
 <br>
 
 https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
 # `SkillWise`
+<br>
+https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
 
 <br>
 <img src='./readme-images/desktop.png'>
@@ -8,8 +10,7 @@
 
 _<i>SkillWise is an innovative online platform designed to help learners of all ages acquire new skills and knowledge. With a wide range of engaging courses and expert instructors, SkillWise provides the tools you need to succeed in today’s competitive world.</i>_
 
-<br>
-https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+
 <br>
 
 <table align="center">


### PR DESCRIPTION
ADD VIDEO OF WEBSITE IN WEBSITE PREVIEW IN README #724

Description
This pull request adds a website preview video to the README file, enhancing the user experience by providing a visual walkthrough of the website. The video is linked via a clickable thumbnail, allowing users to easily view a preview of the platform in action.

The video is hosted externally and displayed via a thumbnail image.
A new section titled "Website Preview" has been added to the README, following the project's description.
Type of change
 New feature (non-breaking change which adds functionality)
Checklist
 My code follows the code style of this project.
 I have followed the contribution guidelines.
 I have performed a self-review of my own code.
 I have ensured my changes don't generate any new warnings or errors.
 I have updated the documentation to reflect the new video preview feature.
 I have resolved all merge conflicts.
