### PR TITLE
ADD VIDEO OF WEBSITE IN WEBSITE PREVIEW IN README #724

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # `SkillWise`
 <br>
 https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
-
 <br>
 <img src='./readme-images/desktop.png'>
 <br>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # `SkillWise`
 <br>
-
+# `SkillWise`
+<br>
 
 https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # `SkillWise`
 <br>
-Website Preview
-<br>
 
 https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # `SkillWise`
 <br>
-https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+
+
+https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57
+
+
 <br>
 <img src='./readme-images/desktop.png'>
 <br>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 _<i>SkillWise is an innovative online platform designed to help learners of all ages acquire new skills and knowledge. With a wide range of engaging courses and expert instructors, SkillWise provides the tools you need to succeed in today’s competitive world.</i>_
 
 <br>
+https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+<br>
 
 <table align="center">
     <thead align="center">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `SkillWise`
 <br>
-# `SkillWise`
+Website Preview
 <br>
 
 https://github.com/user-attachments/assets/f52272a5-0d62-4812-8700-bdb07ab21a57

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
 # `SkillWise`
+<br>
+https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
 
 <br>
 <img src='./readme-images/desktop.png'>
@@ -8,8 +10,7 @@
 
 _<i>SkillWise is an innovative online platform designed to help learners of all ages acquire new skills and knowledge. With a wide range of engaging courses and expert instructors, SkillWise provides the tools you need to succeed in today’s competitive world.</i>_
 
-<br>
-https://github.com/user-attachments/assets/c43af3c7-5655-4e31-8ef8-25a0abfe34e5
+
 <br>
 
 <table align="center">

--- a/assets/css/darkmode.css
+++ b/assets/css/darkmode.css
@@ -1474,14 +1474,16 @@ textarea {
 button {
   margin: auto;
   padding: 10px;
-  background-color: #007bff;
+  font-weight: bold;
+  font-size:large;
+  background-color: #eaecee;
   color: var(--black);
   border: none;
   border-radius: 5px;
   cursor: pointer;
 }
 button:hover {
-  background-color: #0056b3;
+  background-color: #b7c0ca;
 }
 @media (max-width: 992px) {
   .footer-logo-text {

--- a/assets/css/registor_btn.css
+++ b/assets/css/registor_btn.css
@@ -1,0 +1,39 @@
+.register-b {
+    display: inline-block;
+    border-radius: 4px;
+    background-color: #3d405b;
+    border: none;
+    color: #FFFFFF;
+    text-align: center;
+    font-size: 17px;
+    padding: 16px;
+    width: 130px;
+    transition: all 0.5s;
+    cursor: pointer;
+    margin: 5px;
+   }
+   
+   .register-b span {
+    cursor: pointer;
+    display: inline-block;
+    position: relative;
+    transition: 0.5s;
+   }
+   
+   .register-b span:after {
+    content: '»';
+    position: absolute;
+    opacity: 0;
+    top: 0;
+    right: -15px;
+    transition: 0.5s;
+   }
+   
+   .register-b:hover span {
+    padding-right: 15px;
+   }
+   
+   .register-b:hover span:after {
+    opacity: 1;
+    right: 0;
+   }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1838,15 +1838,17 @@ textarea {
 }
 button {
   padding: 15px;
-  background-color: #007bff;
-  color: white;
+  background-color: #eef1f4;
+  font-weight: bold;
+  font-size: large;
+  color: rgb(39, 37, 37);
   border: none;
   border-radius: 5px;
   cursor: pointer;
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: #dbdfe4;
 }
 
 @media (max-width: 1037px) {

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
 <!-- Animation on Scroll -->
 <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
+<link rel="stylesheet" href="registor_btn.css" />
 
 <body>
 
@@ -836,10 +837,32 @@
             Education Is About Creating Leaders For Tomorrow
           </h2>
 
-          <a href="signin.html" class="cta-btn" data-aos="fade-left">Register Today</a>
+          
+          <!-- <a href="signin.html" class="register-button" data-aos="fade-left">Register Today</a> -->
 
+          <!-- <div class="c1-button">
+            <button onclick="window.location.href='signin.html'">
+                Register Today
+            </button>
+        </div> -->
+      
+        <button class="register-b">
+          <span onclick="window.location.href='signin.html'">Register Today</span>
+        </button>
         </div>
       </section>
+
+
+      <!-- <section class="cta-section" aria-labelledby="cta-heading">
+        <div class="cta-wrapper">
+          <h2 class="cta-title" id="cta-heading" data-aos="zoom-in">
+            Education Is About Creating Leaders For Tomorrow
+          </h2>
+          <a href="signin.html" class="cta-button" data-aos="fade-left">Register Today</a>
+        </div>
+      </section> -->
+      
+      
 
       <!-- Live Counting -->
 


### PR DESCRIPTION
ADD VIDEO OF WEBSITE IN WEBSITE PREVIEW IN README https://github.com/PriyaGhosal/SkillWise/issues/724

Before :
![Screenshot 2024-10-19 190103](https://github.com/user-attachments/assets/c6176ae8-da5b-4287-a3b1-081a3fb3c8b4)


After :
![Screenshot 2024-10-19 190247](https://github.com/user-attachments/assets/7cd64ebb-116a-449b-8a55-1ba43ed72b38)


Description
This pull request adds a website preview video to the README file, enhancing the user experience by providing a visual walkthrough of the website. The video is linked via a clickable thumbnail, allowing users to easily view a preview of the platform in action.

The video is hosted externally and displayed via a thumbnail image.
A new section titled "Website Preview" has been added to the README, following the project's description.
Type of change
New feature (non-breaking change which adds functionality)
Checklist
My code follows the code style of this project.
I have followed the contribution guidelines.
I have performed a self-review of my own code.
I have ensured my changes don't generate any new warnings or errors.
I have updated the documentation to reflect the new video preview feature.
I have resolved all merge conflicts.