### PR TITLE
Update signin.html

### DIFF
--- a/signin.html
+++ b/signin.html
@@ -30,6 +30,7 @@
             <p><strong>Sign in</strong> to access your learning dashboard</p>
             
             <form action="#" method="POST">
+                {% csrf_token %}
                 <div class="input-group">
                     <label for="username">Username</label>
                     <input type="text" id="username" name="username" placeholder="Enter your username" required>


### PR DESCRIPTION
Manually-created forms in django templates should specify a csrf_token to prevent CSRF attacks.

References
https://docs.djangoproject.com/en/4.2/howto/csrf/

Explanation:
The {% csrf_token %} tag generates a hidden input field that contains a CSRF token, which is a random string used to verify that the request is coming from the same site and not from a cross-site request. Why CSRF Protection is Important:
Without the CSRF token, an attacker could craft a form on a malicious site that submits data to your application (since it's doing a POST request). The CSRF token ensures that only forms generated by your application can successfully submit data.

Make sure your Django settings have MIDDLEWARE configured with 'django.middleware.csrf.CsrfViewMiddleware' to enforce CSRF protection.