### PR TITLE
fix start free trial button position

### DIFF
--- a/style.css
+++ b/style.css
@@ -182,9 +182,9 @@
 
 #freeTrial{
   position: absolute;
- right: 80px;
-margin-right: 60px;
- 
+  right: 90px;
+  margin-right: 30px;
+  margin-bottom: 30px; 
 
 }
 


### PR DESCRIPTION
### Title of the Pull Request
- [x] Have you renamed the PR Title in a meaningful way?
<!-- 
Examples of good PR titles:

build:      (for build related changes)
chore:      (for updating task runner configs etc; no production code change)
docs:       (for documentation changes)
feat:       (for new feature)
fix:        (for bug fixes)
perf:       (for performance improvements)
refactor:   (for refactoring code; no production code change)
revert:     (when reverting changes)
style:      (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
test:       (when adding missing tests)
-->
### Related Issue
<!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
Closes: https://github.com/PriyaGhosal/SkillWise/issues/798

### Description
previously the start free trial button was not in proper position
previous : 
![image](https://github.com/user-attachments/assets/e5843769-e189-4699-8409-396ee2d5e862)

fix: 
![image](https://github.com/user-attachments/assets/fe2db87e-ba54-44bd-84fc-50893a281e86)


### Type of change

What sort of changes have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [ ] I have updated the documentation (if necessary).
- [x] I have resolved all merge conflicts.