### PR TITLE
Fix: fixed the position of Start free trial box  

### DIFF
--- a/style.css
+++ b/style.css
@@ -183,6 +183,7 @@
 #freeTrial{
   position: absolute;
  right: 80px;
+margin-top: 60px;
 margin-right: 60px;
  
 


### PR DESCRIPTION
### Title of the Pull Request
- [✔] Have you renamed the PR Title in a meaningful way?
### Related Issue
Closes: #<797>

### Description
In this pull request, I have:

Fixed the position of a button Start Free Trial in the navigation bar, which was previously overlapping with and hiding part of the search bar. This update ensures better visibility and functionality of the search bar.

### Type of change
- [✔] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [✔] My code follows the code style of this project.
- [✔] I have followed the contribution guidelines
- [✔] I have performed a self-review of my own code.
- [✔] I have ensured my changes don't generate any new warnings or errors.
- [ ✘ ] I have updated the documentation (if necessary).
- [✔] I have resolved all merge conflicts.
![image](https://github.com/user-attachments/assets/3c586442-bc32-4a04-acf3-7510663e3a86)
