### PR TITLE
Edited the copyright section in the footer is clear to visible now

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -125,7 +125,7 @@ html {
 
 body {
   background-color: var(--snow);
-  color: var(--roman-silver);
+  color: #ff8086;
   font-size: 1.6rem;
   line-height: 1.5;
   overflow: hidden;


### PR DESCRIPTION
#792
*Footer section
    Edited the copyright section in the footer is clear to visible now to 
<img width="1440" alt="Screenshot 2024-10-23 at 1 35 34 AM" src="https://github.com/user-attachments/assets/05a2b1b5-c35b-471e-a43a-d3545546d6c8">
users
<img width="1440" alt="Screenshot 2024-10-23 at 1 36 14 AM" src="https://github.com/user-attachments/assets/b7456e70-9b9b-464e-b2b7-130a26a4ee8d">
@PriyaGhosal 