### PR TITLE
Am edited the copyright in the  footer section of dark theme

### DIFF
--- a/assets/css/darkmode.css
+++ b/assets/css/darkmode.css
@@ -1177,6 +1177,7 @@ button:hover {
 
 .copyright {
   font-weight: var(--fw-500);
+  color:#ff8086;
 }
 
 #instapost1 {


### PR DESCRIPTION
#817 
In the dark theme footer section of the copyright is edited, right now the copyright is clear visible 
@PriyaGhosal 
<img width="1440" alt="Screenshot 2024-10-23 at 11 55 18 PM" src="https://github.com/user-attachments/assets/a1b6b764-4e32-4186-bd64-fbb64f2c71e3">
<img width="1440" alt="Screenshot 2024-10-24 at 12 02 35 AM" src="https://github.com/user-attachments/assets/3ab54fbd-c2bc-451d-9fde-9507210a230c">
