### PR TITLE
Bug : Added the width of nav button Start free trial in FAQ page

### DIFF
--- a/assets/css/Faq.css
+++ b/assets/css/Faq.css
@@ -184,3 +184,6 @@ body {
   overflow-y: auto; /* Enable vertical scroll */
 }
 
+#freeTrial{
+  width: 240px;
+}

--- a/assets/css/Faq.css
+++ b/assets/css/Faq.css
@@ -186,4 +186,5 @@ body {
 
 #freeTrial{
   width: 240px;
+  padding-top: 10px;
 }

--- a/assets/css/Faq.css
+++ b/assets/css/Faq.css
@@ -187,4 +187,5 @@ body {
 #freeTrial{
   width: 240px;
   padding-top: 10px;
+  margin-top: 5px;
 }


### PR DESCRIPTION
Title of the Pull Request
[✔] Have you renamed the PR Title in a meaningful way?
Related Issue
Closes: #844 

Description
In the FAQ page the nav button Start free trial width is less so increase it to enhance UI/UX 

Type of change
What sort of changes have you made:

[✔] Bug fix (non-breaking change which fixes an issue)
[✔] New feature (non-breaking change which adds functionality)
[✘] Code style update (formatting, local variables)
[✘] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[✘] This change requires a documentation update

Checklist
[✔] My code follows the code style of this project.
[✔] I have followed the contribution guidelines
[✔] I have performed a self-review of my own code.
[✔] I have ensured my changes don't generate any new warnings or errors.
[✘] I have updated the documentation (if necessary).
[✔] I have resolved all merge conflicts.
![image](https://github.com/user-attachments/assets/3982b263-0044-4e5d-89ca-3fadc6b0de09)
