### PR TITLE
Fix : 'Start Free Trial' button text alignment to single line in FAQ section for consistency

### DIFF
--- a/assets/css/Faq.css
+++ b/assets/css/Faq.css
@@ -42,6 +42,10 @@
   background-color: hsl(357, 85%, 81%);
 }
 
+#freeTrial{
+  width: 240px;
+}
+
 .FAQ-title {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION

### Title of the Pull Request
- [ X ] Have you renamed the PR Title in a meaningful way?

### Related Issue
Closes: #862

### Description
Fixed the alignment of the "Start Free Trial" button text in the FAQ section. The text now appears on a single line, consistent with other pages.

### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
- [ x ] My code follows the code style of this project.
- [ x ] I have followed the contribution guidelines
- [ x ] I have performed a self-review of my own code.
- [ x ] I have ensured my changes don't generate any new warnings or errors.
- [ x ] I have updated the documentation (if necessary).
- [ x ] I have resolved all merge conflicts.

Before :                                                                                    
![Screenshot (28)](https://github.com/user-attachments/assets/297ada21-aac6-4147-81d3-8f183acc9f4f)

After : 
![Screenshot (29)](https://github.com/user-attachments/assets/1fd3ab89-8f1f-446b-a85f-2cbb1b15ed62)
