### PR TITLE
fix: "Buy our E-book" button visibility in night mode

### DIFF
--- a/assets/css/darkmode.css
+++ b/assets/css/darkmode.css
@@ -494,6 +494,23 @@ body.nav-active {
 }
 
 /*-----------------------------------*\
+  #E-book
+\*-----------------------------------*/
+
+.E-book-button {
+  position: fixed;
+  left: 20px;
+  bottom: 80px; 
+  background-color: #FF4D4D;
+  color: white;
+  padding: 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  z-index: 1001; 
+}
+
+/*-----------------------------------*\
   #Feedback
 \*-----------------------------------*/
 


### PR DESCRIPTION
### Title of the Pull Request
fix: "Buy our E-book" button visibility in night mode

- [x] Have you renamed the PR Title in a meaningful way?

### Related Issue
Closes: #866 

### Description

The "Buy our E-book" button was not visible in night mode due to insufficient contrast with the background. Updated the button's CSS in `assets\css\darkmode.css` to ensure it has a suitable color in night mode for better visibility. Added a contrasting background color and text color to the button to maintain readability across themes.


### After made Change how it look:


https://github.com/user-attachments/assets/2e906d3a-5da5-49d6-a044-29f3f03da7fd



### Type of change
What sort of changes have you made:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [ ] I have updated the documentation (if necessary).
- [x] I have resolved all merge conflicts.

